### PR TITLE
Add image support for blog posts

### DIFF
--- a/components/blog/MarkdownRenderer.tsx
+++ b/components/blog/MarkdownRenderer.tsx
@@ -25,6 +25,12 @@ export default function MarkdownRenderer({ content }: { content: string }) {
                         {...props}
                     />
                 ),
+                img: (props) => (
+                    <img
+                        className="my-4 max-w-full h-auto mx-auto"
+                        {...props}
+                    />
+                ),
                 code({ node, inline, className, children, ...props }: any) {
                     const match = /language-(\w+)/.exec(className || "")
                     return !inline && match ? (


### PR DESCRIPTION
## Summary
- set up `public/images` directory for future blog assets
- render markdown images with consistent styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891a4da87a8832ca5047b1869d78932